### PR TITLE
faster than Parse.lean

### DIFF
--- a/lean-sat/lean-toolchain
+++ b/lean-sat/lean-toolchain
@@ -1,1 +1,1 @@
-custom
+leanprover/lean4-pr-releases:pr-release-4774

--- a/parse-lean/Main.lean
+++ b/parse-lean/Main.lean
@@ -220,4 +220,7 @@ def parse (ba: ByteArray) : IO Unit := do
 
 def main : IO Unit := do
   let input ← IO.FS.readBinFile "./test.txt"
+  let t1 ← IO.monoMsNow
   parse input
+  let t2 ← IO.monoMsNow
+  IO.println s!"Parsing took {t2 - t1}ms"


### PR DESCRIPTION
This yields:
```
florence:~/Desktop/formal_verification/lean/parse.lean-bench/lean-sat|main
λ lake exe tests                                                                                                                                                                                                                                                                   
Parsed 874 chunks and 172033 headers
Parsing took 103ms
florence:~/Desktop/formal_verification/lean/parse.lean-bench/parse-lean|main
λ lake exe tests
[Parse.lean] Parsed 874 chunks and 172033 headers
Parsing took 125ms
```